### PR TITLE
Fix for building with Xcode 8

### DIFF
--- a/TradeItIosAdSdk/SSLPinningDelegate.swift
+++ b/TradeItIosAdSdk/SSLPinningDelegate.swift
@@ -25,9 +25,9 @@ class SSLPinningDelegate: NSObject, NSURLSessionDelegate {
         SecTrustSetPolicies(serverTrust!, policies);
 
         // Evaluate server certificate
-        var result: SecTrustResultType = 0
+        var result: SecTrustResultType = SecTrustResultType.Invalid
         SecTrustEvaluate(serverTrust!, &result)
-        return (Int(result) == kSecTrustResultUnspecified || Int(result) == kSecTrustResultProceed)
+        return (result == SecTrustResultType.Unspecified || result == SecTrustResultType.Proceed)
     }
 
     func isSSLCertificateMatching(certificate: SecCertificate?) -> Bool {


### PR DESCRIPTION
Without converting to Swift 3.0 syntax (Setting "Use Legacy Swift Language Version: YES), was still get errors compiling Ad pod.   
